### PR TITLE
Removed encryption from autonomous agent

### DIFF
--- a/bin/pattoo_agent_linux_autonomousd.py
+++ b/bin/pattoo_agent_linux_autonomousd.py
@@ -48,19 +48,6 @@ class PollingAgent(Agent):
         Agent.__init__(self, parent)
         self._parent = parent
 
-        # Add email address to Agent subclass
-        econfig = Config()
-        self.set_email(econfig.agent_email_address())
-
-        # Email address must be the same in the first created Pgpier
-        # object for the agent as the one in the yaml file
-        # or else an error might occur. To use a
-        # different email address, delete the contents of the
-        # key folder
-
-        # Set up encryption using Pgpier in Agent
-        self.gpg = self.set_gnupg() # Creation and retrieval of Pgpier object
-
     def query(self):
         """Query all remote targets for data.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -55,7 +55,8 @@ Run the code block below to install the BACnet agent
 
 Stopping, Starting and Restarting daemons
 ------------------------------------------
-By default, the installation starts the daemons, and restarts them if they are already running, however, if you desire to start, stop or restart the system daemon for the linux agent after the installation the following code blocks should assist:
+By default, the installation starts the daemons if they aren't running, and restarts them if they are already running,
+ however, if you desire to start, stop or restart the system daemon for the linux agent after the installation the following code blocks should assist:
 
 **Starting daemon**
    .. code-block:: bash

--- a/setup/install.py
+++ b/setup/install.py
@@ -267,6 +267,7 @@ def main():
     checks.installation_checks()
     checks.pattoo_shared_check()
     checks.venv_check()
+
     # Process the CLI
     _parser = Parser(additional_help=_help)
     (args, parser) = _parser.args()


### PR DESCRIPTION
While attempting to start the daemons in docker, the autonomous daemon would fail to start due to the encryption methods being removed from the agent class in PattooShared.